### PR TITLE
Correct dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "lib": "dist/amd"
   },
   "dependencies": {
-    "leaflet": "Leaflet/Leaflet@^0.7.3"
+    "leaflet": "Leaflet/Leaflet@0.7.3"
   }
 }


### PR DESCRIPTION
Now that the 0.7.7 leaflet is release, I have the bug that the marker doesn't show because of a file doesn't found in jspm_packages/github/Leaflet/Leaflet@0.7.7/dist/images.

I see that the number 0.7.3 is writen in hardcode here: https://github.com/benib/aurelia-leaflet/blob/0.1.1/src/index.js#L4

For this reason, only the leaflet 0.7.3 is compatible with your code, no?

Anyway, thanks for this plugin :)
