### PR TITLE
remove file extension in globalResources call

### DIFF
--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -17,6 +17,6 @@ define(['exports', 'leaflet'], function (exports, _leaflet) {
     var LeafletDefaultImagePath = _ref$LeafletDefaultImagePath === undefined ? 'jspm_packages/github/Leaflet/Leaflet@0.7.7/dist/images' : _ref$LeafletDefaultImagePath;
 
     _Leaflet['default'].Icon.Default.imagePath = LeafletDefaultImagePath;
-    frameworkConfig.globalResources('./leaflet.js');
+    frameworkConfig.globalResources('./leaflet');
   }
 });


### PR DESCRIPTION
Improves compat w/aurelia-cli and jspm with defaultJSExtensions
