### PR TITLE
BUG FIX Don't add existing layers again

### DIFF
--- a/src/leaflet.js
+++ b/src/leaflet.js
@@ -160,12 +160,16 @@ export class LeafletCustomElement {
     };
     if (this.layers.hasOwnProperty('base')) {
       for (let layer of this.layers.base) {
-        layersToAttach.base[this.getLayerId(layer)] = this.layerFactory.getLayer(layer);
+        const id = this.getLayerId(layer);
+        if (this.attachedLayers.base.hasOwnProperty(id)) { continue; }
+        layersToAttach.base[id] = this.layerFactory.getLayer(layer);
       }
     }
     if (this.layers.hasOwnProperty('overlay')) {
       for (let layer of this.layers.overlay) {
-        layersToAttach.overlay[this.getLayerId(layer)] = this.layerFactory.getLayer(layer);
+        const id = this.getLayerId(layer);
+        if (this.attachedLayers.overlay.hasOwnProperty(id)) { continue; }
+        layersToAttach.overlay[id] = this.layerFactory.getLayer(layer);
       }
     }
     this.mapInit.then(() => {


### PR DESCRIPTION
BUG: I've noticed that, when removing a layer, the remaining layers were added again. As they are added on top of each other, you cannot see it, but you can check it in your DOM tree. 

FIX: The problem occurs in leaflet.js, in the attachLayers function. It doesn't check whether an existing layer is already attached. All I needed to do was to change (line 161)
```js
    if (this.layers.hasOwnProperty('base')) {
      for (let layer of this.layers.base) {
        layersToAttach.base[this.getLayerId(layer)] = this.layerFactory.getLayer(layer);
      }
    }
    if (this.layers.hasOwnProperty('overlay')) {
      for (let layer of this.layers.overlay) {
        layersToAttach.overlay[this.getLayerId(layer)] = this.layerFactory.getLayer(layer);
      }
    }
```
into
```ts
    if (this.layers.hasOwnProperty('base')) {
      for (let layer of this.layers.base) {
        const id = this.getLayerId(layer);
        if (this.attachedLayers.base.hasOwnProperty(id)) { continue; }
        layersToAttach.base[id] = this.layerFactory.getLayer(layer);
      }
    }
    if (this.layers.hasOwnProperty('overlay')) {
      for (let layer of this.layers.overlay) {
        const id = this.getLayerId(layer);
        if (this.attachedLayers.overlay.hasOwnProperty(id)) { continue; }
        layersToAttach.overlay[this.getLayerId(layer)] = this.layerFactory.getLayer(layer);
      }
    }
```